### PR TITLE
Add Azure OpenAI Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # setup your LLM API config , ref https://api-docs.deepseek.com/
+# setup your LLM API config , ref https://api-docs.deepseek.com/
 LLM_MODEL=deepseek-chat
 LLM_BASE_URL=https://api.deepseek.com
 LLM_API_KEY=sk-xxxxxx
+API_VERSION=
+OPENAI_PROVIDER=

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 # setup your LLM API config , ref https://api-docs.deepseek.com/
-# setup your LLM API config , ref https://api-docs.deepseek.com/
 LLM_MODEL=deepseek-chat
 LLM_BASE_URL=https://api.deepseek.com
 LLM_API_KEY=sk-xxxxxx

--- a/utils/call_llm_api.py
+++ b/utils/call_llm_api.py
@@ -4,7 +4,7 @@ import json
 import requests
 import re
 
-from openai import OpenAI
+from openai import OpenAI, AzureOpenAI
 from dotenv import load_dotenv
 
 from utils.logger import logger
@@ -18,7 +18,16 @@ class LLMCompletionCall:
         self.llm_api_key = os.getenv("LLM_API_KEY", "")
         if not self.llm_api_key:
             raise ValueError("LLM API key not provided")
-        self.client = OpenAI(base_url=self.llm_base_url, api_key = self.llm_api_key)
+        self.openai_provider = os.getenv("OPENAI_PROVIDER", "openai").lower()
+        if self.openai_provider == "azure":
+            self.api_version = os.getenv("API_VERSION", "2025-01-01-preview")
+            self.client = AzureOpenAI(
+                    azure_endpoint=self.llm_base_url,
+                    api_key=self.llm_api_key,
+                    api_version=self.api_version,
+                )
+        else:
+            self.client = OpenAI(base_url=self.llm_base_url, api_key = self.llm_api_key)
 
     def call_api(self, content: str) -> str:
         """


### PR DESCRIPTION
This pull request introduces support for using Azure OpenAI as an alternative provider for LLM API calls, in addition to the existing OpenAI provider. It adds configuration options to select the provider and specify the API version, and updates the initialization logic to instantiate the correct client based on these settings.

Configuration enhancements:

* Added `API_VERSION` and `OPENAI_PROVIDER` variables to `.env.example` to allow selection of provider and API version for LLM API calls.

Provider selection and initialization:

* Updated `utils/call_llm_api.py` to import `AzureOpenAI` and read the `OPENAI_PROVIDER` environment variable to determine which client to use.
* Modified the `__init__` method in `utils/call_llm_api.py` to instantiate `AzureOpenAI` with the appropriate parameters when `OPENAI_PROVIDER` is set to "azure", including support for specifying `API_VERSION`. Otherwise, it defaults to the standard `OpenAI` client.